### PR TITLE
Improve partials (helpdesk 55473)

### DIFF
--- a/arborelastic.module
+++ b/arborelastic.module
@@ -45,6 +45,8 @@ function arborelastic_search($path_id, $query, $args = [])
     $search_escapes = [',', '-'];
     $search_replace = ['', ' '];
     $query = str_replace($search_escapes, $search_replace, $query);
+    // store raw query so we don't have to str_replace fuzziness later
+    $flatQuery = $query;
     $fuzzy = explode(' ', $query);
     $query = [];
     foreach ($fuzzy as $fuz) {
@@ -222,12 +224,32 @@ function arborelastic_search($path_id, $query, $args = [])
             // the extra layer of array brackets is so we can add more to the must/should conditions
             'must' => [
               [
-                'query_string' => [
-                  'query' => $query,
-                  'fields' => ['title.folded^20', 'author.folded^10', 'artist.folded^10', 'callnum', 'callnums', 'subjects', 'series', 'addl_author', 'addl_title'],
-                  'default_operator' => 'and',
-                  'fuzziness' => '1',
-                  'fuzzy_prefix_length' => 3,
+                'bool' => [
+                  'should' => [
+                    [
+                      'query_string' => [
+                        'query' => $query,
+                        'fields' => ['title.folded^20', 'author.folded^10', 'artist.folded^10', 'callnum', 'callnums', 'subjects', 'series', 'addl_author', 'addl_title'],
+                        'default_operator' => 'and',
+                        'fuzziness' => '1',
+                        'fuzzy_prefix_length' => 3,
+                      ]
+                    ],
+                    [
+                      'match' => [
+                        'title' => [
+                          'query' => $flatQuery,
+                          'minimum_should_match' => '70%'
+                        ]
+                      ]
+                    ]
+                  ],
+                ]
+              ],
+              // this is partially redundant given that we are adding active to the first query string query above. can be removed later with a more comprehensive rework.
+              [
+                'match' => [
+                  'active' => 1
                 ]
               ]
             ],

--- a/arborelastic.module
+++ b/arborelastic.module
@@ -70,12 +70,6 @@ function arborelastic_search($path_id, $query, $args = [])
   $es_client = ClientBuilder::create()->setHosts($hosts)->build();
   $size = 25; // default number of results to return
   $from = 0;
-
-  // Limit search results to active
-  if ($index == 'bibs') {
-    $args['active'] = $_GET['active'] ?? 1;
-  }
-
   // Parse Args and add to query string
   foreach ($args as $field => $value) {
     if ($field == 'fbclid') {
@@ -246,12 +240,6 @@ function arborelastic_search($path_id, $query, $args = [])
                   ],
                 ]
               ],
-              // this is partially redundant given that we are adding active to the first query string query above. can be removed later with a more comprehensive rework.
-              [
-                'match' => [
-                  'active' => 1
-                ]
-              ]
             ],
             'should' => [
               [
@@ -305,6 +293,14 @@ function arborelastic_search($path_id, $query, $args = [])
         ]
       ];
     }
+  }
+  // this replaces the AND active on the top-level query string to work with sidebar filters
+  if (!isset($_GET['active'])) {
+    $es_query['function_score']['query']['bool']['must'][] = [
+      'match' => [
+        'active' => 1
+      ]
+    ];
   }
 
   $params = [


### PR DESCRIPTION
This nests a should block underneath the top-level must block in bib index queries to improve partial matches. At the moment, it's only including partial matches on titles. Thinking there is that titles are longer and author misspellings are more likely to be caught by the default fuzziness of the query_string. 

It also changes how active is applied. It's removed as an AND argument from the query_string and conditionally appended to the must block unless the 'Include suppressed' sidebar filter is ticked.

Queries against prod and pinkeye return the alternate title shared in [this helpdesk](https://staff.aadl.org/node/55473).  Prod speed doesn't seem any slower, but pinkeye is definitely a bit slower with this change. Pinkeye is significantly slower at handling queries overall, but this change does seem to be a bit more expensive.  Happy to test on the dev site before merging if we want to dig further into resource usage.