### PR TITLE
Broadened author queryables

### DIFF
--- a/src/Search/ArborElasticQuery.php
+++ b/src/Search/ArborElasticQuery.php
@@ -146,7 +146,7 @@ class ArborElasticQuery
     $this->applyMatchTerms();
     $this->applySortTerms();
     $this->applyFlatBoosts();
-    dd(json_encode($this->es_query['body']));
+
     try {
       $result = $this->connection->search($this->es_query);
     } catch (\Exception $e) {

--- a/src/Search/ArborElasticQuery.php
+++ b/src/Search/ArborElasticQuery.php
@@ -34,6 +34,7 @@ class ArborElasticQuery
             'function_score' => [
               'query' => [
                 'bool' => [
+                  'must' => [],
                   'should' => [
                     [
                       'match' => [
@@ -145,7 +146,7 @@ class ArborElasticQuery
     $this->applyMatchTerms();
     $this->applySortTerms();
     $this->applyFlatBoosts();
-
+    dd(json_encode($this->es_query['body']));
     try {
       $result = $this->connection->search($this->es_query);
     } catch (\Exception $e) {
@@ -393,7 +394,7 @@ class ArborElasticQuery
   }
   private function enforceExactMatches($key, $value)
   {
-    $this->es_query['body']['query']['function_score']['query']['bool']['must'][] = [
+    $this->es_query['body']['query']['function_score']['query']['bool']['must']['bool']['must'][] = [
       'query_string' => [
         'query' => $key . ':' . $value,
       ]


### PR DESCRIPTION
Addresses the overdrive author issue by handing author queries using a looser match query. Also moves all queryables into a nested bool->must->bool->should, which is effectively just an OR. Tested locally and pulled to dev. It's a fairly isolated change so queries that don't contain queryables (e.g., author:* or title:*) won't be affected at all. Generally the queries affected a bit broader, but not by much.

Could better be addressed with an analyzer on the primaryCreator->name field in overdrive later.

Edit: caught a problem that was affecting searches with multiple folded queryables using exact matches. Nested exact match queryables into the second bool to avoid problems with improper indexes in assoc arrays.