### PR TITLE
Flat relevancy reduction of overdrive vs AADL

### DIFF
--- a/src/Search/ArborElasticQuery.php
+++ b/src/Search/ArborElasticQuery.php
@@ -411,6 +411,18 @@ class ArborElasticQuery
         "boost" => 500
       ]
     ];
+    // Reduces Overdrive relevance compared to AADL-owned items
+    $this->es_query['body']['query']['function_score']['query']['bool']['should'][] = [
+      'bool' => [
+        'should' =>
+        [
+          "match" => [
+            "bib_type" => "Overdrive",
+          ]
+        ],
+        "boost" => 0.7
+      ]
+    ];
   }
   private function handleOverdrive($value)
   {


### PR DESCRIPTION
Adds a 0.7 boost to items matching bib_type: overdrive to ensure that AADL-owned items appear ahead. 

I tinkered with the number a little bit, and this seems to do okay with placing relevant overdrive bibs above less relevant in-house bibs. 

The intent is that if a longer query matches a title in an AADL item sorta matches but not as much as the overdrive bib, the Overdrive bib may still appear above the AADL item. For cases where the query is short, like the Roblox issue that came up recently, Overdrive bibs should almost always be below AADL items.