### PR TITLE
Improve short stop word phrases

### DIFF
--- a/src/Search/ArborElasticQuery.php
+++ b/src/Search/ArborElasticQuery.php
@@ -404,9 +404,10 @@ class ArborElasticQuery
   {
     // Helps boost closer exact matches over partial matches in broader queries
     $this->es_query['body']['query']['function_score']['query']['bool']['should'][] = [
-      'query_string' =>
+      'multi_match' =>
       [
         "query" => $this->query,
+        "type" => "phrase_prefix",
         "fields" => ['title', 'author', 'artist'],
         "boost" => 500
       ]


### PR DESCRIPTION
I know we're trying to keep updates to search to a minimum, but the helpdesk this morning definitely revealed that short 3-4 word phrases beginning with stop words are prompting exceptionally poor results at the moment and should be fixed. This small update doesn't change much other than that. 

It changes the query_string on the exact match boost to a phrase_prefix match, which scores better within a function_score query and so lifts up close matches better.

In the future, a stop word analyzer might be useful for titles. But could use some thought & discussion.

Here are some examples of the improvement:

Before: [The Inside Game](https://aadl.org/search/catalog/the%20inside%20game)
After: [The Inside Game](https://dev.aadl.org/search/catalog/the%20inside%20game)

Before: [The roman empire ](https://aadl.org/search/catalog/the%20roman%20empire)
After: [The roman empire](https://dev.aadl.org/search/catalog/the%20roman%20empire)

Before: [The memory index](https://aadl.org/search/catalog/The%20memory%20index)
After: [The memory index](https://dev.aadl.org/search/catalog/The%20memory%20index)
