### PR TITLE
log1p and regex fix

### DIFF
--- a/src/Search/ArborElasticQuery.php
+++ b/src/Search/ArborElasticQuery.php
@@ -49,7 +49,7 @@ class ArborElasticQuery
               'field_value_factor' => [
                 'field' => 'popular_alltime',
                 'modifier' => 'log1p',
-                'missing' => 1
+                'missing' => 0
               ]
             ]
           ],
@@ -183,7 +183,7 @@ class ArborElasticQuery
     $queryables = [];
 
     // match all : separated terms and iterate over the resulting key value pairs. Concatenate a query_string for as many as are supplied, checking against folded fields
-    preg_match_all('/([a-z]\S*):(["\'\da-z\s].+?(?=(?:[a-z]\S*:|$)))/', $this->query, $matches);
+    preg_match_all('/([a-z]\S*):(["\'\da-zA-Z\s].+?(?=(?:[a-z]\S*:|$)))/', $this->query, $matches);
     $keys = $matches[1];
     $values = $matches[2];
     // place terms into array to then iterate over again to check for operators. Doing this separately is less efficient but easier to handle.
@@ -193,6 +193,7 @@ class ArborElasticQuery
 
           // Authors need broader handling for overdrive. Might be better addressed with an analyzer in the future.
           if ($k === 'author') {
+            $this->query = str_replace('author:', '', $this->query);
             $this->handleOverdrive($values[$i]);
           } else {
 


### PR DESCRIPTION
Other than placing AADL items on an even popularity modifier as overdrive records, these changes are functional bugfixes only and don't affect rankings. They fix errors where queries returned empty when they shouldn't.

1. I neglected to include A-Z in the queryable regex, so queries like author:"zadie smith" would work, but queries like author:Zadie Smith wouldn't. 

2. When the overdrive exception was added, I didn't account for the broken pattern in the queryable. Adding the raw value without its key prevents the fallback query from being triggered with a key. That fallback query would result in some author queries that weren't precisely formatted to return nothing when they ought to, because the whole string "author:{whatever}" was being included as a multimatch.

3. Finally, the overdrive missing parameter is changed to 0 so that they don't have an edge over AADL items with no hold history anymore.