### PR TITLE
Apply prefixed floating string to wildcard field

### DIFF
--- a/src/Search/ArborElasticQuery.php
+++ b/src/Search/ArborElasticQuery.php
@@ -364,17 +364,6 @@ class ArborElasticQuery
           ]
         ]
       ];
-      // Fallback for when operators are present in a catalog query without fields specified. Won't usally be hit or required. 
-      // May want to consider reformatting this method to accomodate conditional formats rather than the current config-like setup.
-      if ($this->path_id === 'catalog' && (strpos($this->query, ' AND ') || strpos($this->query, ' OR ') || strpos($this->query, '*'))) {
-        $formats['catalog']['bool']['should'][] =  [
-          'query_string' => [
-            "query" =>   $this->query,
-            "type" => "cross_fields",
-            "fields" => ['title.folded^20', 'author.folded^10', 'artist.folded^10', 'callnum', 'callnums', 'subjects', 'series', 'addl_author', 'addl_title', 'title_medium'],
-          ]
-        ];
-      }
       $this->es_query['body']['query']['function_score']['query']['bool']['must'][] = $formats[$this->path_id];
     }
   }


### PR DESCRIPTION
- Allows floating prefixed queries against all fields, so [{ducks AND pigeon callnums:"picture books"}](https://dev.aadl.org/search/catalog/ducks%20AND%20pigeons%20callnums:%22picture%20books%22) is supported. 

- Fix the[ boolean operators in baseline queries](https://dev.aadl.org/search/catalog/herbalists%20AND%20fiction), which had been disrupted by the phrase_prefix clauses implemented to improve short words.

- Also removes errant "suggest" field which doesn't line up with anything in the index.

-  Removes 2<90% word containment from multi_match, as the layered combined_fields and overall minimum_should_match is sufficient. This is helpful for instances where patrons are trying to match against [single word titles with only an author's last name. ](https://dev.aadl.org/search/catalog/grafton%20deadbeat)

I also added a development & feature prefix pattern for this repo, as there's also an intent to add either a stemmer or ngram analyzer later to help match roots against pluralizations and suffixes. Thought it might help with some incremental A/B testing, because that change likely to change results overall more than this one. Open to another workflow if anyone who wants to contribute has a simpler one in mind.