### PR TITLE
Append notes matches

### DIFF
--- a/src/Search/ArborElasticQuery.php
+++ b/src/Search/ArborElasticQuery.php
@@ -303,13 +303,29 @@ class ArborElasticQuery
               /* 
                 Helps relevancy of multi-faceted queries (e.g. {some title} {some author}). 
                 If there are only 2 words, it requires all to match somewhere in the set. 
-                if there are more, it maxes out at 4 requiring matches among the set. 
+                if there are more, it maxes out at 4 requiring matches among the set. Having 
+                notes duplicated within an additional clause allows the removal of many 
+                instances of common words and phrases bloating results by requiring its 
+                occurrence in notes to be literal if a portion is hit by combined_fields
               */
               [
-                'combined_fields' => [
-                  "query" => $this->query,
-                  "fields" =>  ['title', 'author', 'artist', 'callnum', 'callnums', 'subjects', 'series', 'addl_author', 'addl_title', 'title_medium'],
-                  "minimum_should_match" => "3<4",
+                'bool' => [
+                  'must' => [
+                    [
+                      'combined_fields' => [
+                        "query" => $this->query,
+                        "fields" => ['title', 'author', 'artist', 'callnum', 'callnums', 'subjects', 'series', 'addl_author', 'addl_title', 'title_medium', 'notes'],
+                        "minimum_should_match" => "3<4"
+                      ],
+                    ],
+                    [
+                      'query_string' => [
+                        "query" => $this->query,
+                        "fields" => ['notes'],
+                        "default_operator" => 'and'
+                      ],
+                    ],
+                  ],
                 ]
               ],
               /* 
@@ -338,7 +354,7 @@ class ArborElasticQuery
                 fuzzy matches on author/title, and the same broad combined_fields query as above. Tri-gram matches 
                 should be used ahead of fuzzy matches. And combined field matches will be used above all. This
                 maintains the ability to do cross field searches without inline fields and still receive accurate
-                results
+                results. The lowest fuzzy bool group includes notes to ensure low ranking of incidental occurrences 
               */
               [
                 'dis_max' => [
@@ -371,25 +387,39 @@ class ArborElasticQuery
                       ]
                     ],
                     [
-                      'match' => [
-                        'title.folded' => [
-                          "query" =>  $this->query,
-                          "fuzziness" => 'AUTO',
-                          "prefix_length" => 3,
-                          "boost" => 0,
-                          "operator" => 'and'
-                        ]
-                      ]
-                    ],
-                    [
-                      'match' => [
-                        'author.folded' => [
-                          "query" =>  $this->query,
-                          "fuzziness" => 'AUTO',
-                          "prefix_length" => 3,
-                          "boost" => 0,
-                          "operator" => 'and'
-                        ]
+                      'bool' => [
+                        'should' => [
+                          [
+                            'match' => [
+                              'title.folded' => [
+                                "query" =>  $this->query,
+                                "fuzziness" => 'AUTO',
+                                "prefix_length" => 3,
+                                "boost" => 0,
+                                "operator" => 'and'
+                              ]
+                            ]
+                          ],
+                          [
+                            'match' => [
+                              'author.folded' => [
+                                "query" =>  $this->query,
+                                "fuzziness" => 'AUTO',
+                                "prefix_length" => 3,
+                                "boost" => 0,
+                                "operator" => 'and'
+                              ]
+                            ]
+                          ],
+                          [
+                            'query_string' => [
+                              "query" => '"' . $this->query . '"',
+                              "fields" => ['notes'],
+                              "default_operator" => 'and'
+                            ],
+                          ],
+                        ],
+                        "minimum_should_match" => 1
                       ]
                     ],
                   ],


### PR DESCRIPTION
Appends notes matches to existing results. Shouldn't really affect the first few pages of results unless the existing results are particularly short for the current query. Common sequential phrases that might be used descriptively in notes/tracks, but not in titles/subjects/etc. apply here. (i.e., "windy city," "lightning strike," "bite the bullet," etc.) 

Single word queries will have their results expanded significantly, but the new results should largely be appended to the previous results. Queries composed of 2+ words will require an exact match within the notes to show up for the most part. 

One exception is if the item is on the very edge of qualifying for the current make up of the primary combined_fields query. Inexact matches on notes will push an item over the top. It still ought to rank low. For example, one additional item makes its way into "adult fiction spy" due to this:
Old: https://aadl.org/search/catalog/adult%20fiction%20spy
New: https://dev.aadl.org/search/catalog/adult%20fiction%20spy

The index on pinkeye is current with production elastic as of the morning of 6/24