### PR TITLE
Remove exact match from wildcard field queries

### DIFF
--- a/src/Search/ArborElasticQuery.php
+++ b/src/Search/ArborElasticQuery.php
@@ -580,15 +580,17 @@ class ArborElasticQuery
   }
   private function applyFlatBoosts()
   {
-    // Helps boost closer exact matches over partial matches in broader queries
-    $this->es_query['body']['query']['function_score']['query']['bool']['should'][] = [
-      'query_string' =>
-      [
-        "query" => $this->query,
-        "fields" => ['title', 'author', 'artist'],
-        "boost" => 100
-      ]
-    ];
+    // Helps boost closer exact matches over partial matches in broader queries, not included in wildcard queries
+    if (!str_contains($this->query, '*')) {
+      $this->es_query['body']['query']['function_score']['query']['bool']['should'][] = [
+        'query_string' =>
+        [
+          "query" => $this->query,
+          "fields" => ['title', 'author', 'artist'],
+          "boost" => 100
+        ]
+      ];
+    }
     // Reduces Overdrive relevance compared to AADL-owned items
     $this->es_query['body']['query']['function_score']['query']['bool']['should'][] = [
       'bool' => [


### PR DESCRIPTION
This fixes the issue brought up by Chris forwarded by Eli. After the update two weeks ago, queries with wildcard fields were having the exact match applied without an escaped wildcard. There's no need for exact matching when wildcards are used, so I've just removed that chunk when * wildcards are present.