### PR TITLE
Series term & fuzz weight adjustments

### DIFF
--- a/src/Search/ArborElasticQuery.php
+++ b/src/Search/ArborElasticQuery.php
@@ -218,6 +218,9 @@ class ArborElasticQuery
         ],
         'stemmed' => [
           'subjects'
+        ],
+        'term' => [
+          'series'
         ]
       ],
       'community' => [
@@ -269,6 +272,18 @@ class ArborElasticQuery
         } else if (in_array($k, $search_fields[$this->path_id]['stemmed'])) {
           $queryables[] = $k . '.stem:(' . trim($values[$i]) . ')';
         } else {
+          if (in_array($k, $search_fields[$this->path_id]['term']) && preg_match('/^"(.*?)"/', $values[$i])) {
+
+            $this->es_query['body']['query']['function_score']['query']['bool']['must'][] = [
+              'term' => [
+                $k . '.keyword' => [
+                  'value' => str_replace('"', '', $values[$i]),
+                  'case_insensitive' => true
+                ]
+              ]
+
+            ];
+          }
           $queryables[] = $k . ':(' . trim($values[$i]) . ')';
         }
       }
@@ -358,7 +373,7 @@ class ArborElasticQuery
               [
                 'multi_match' => [
                   "query" => strtolower($this->query),
-                  "fields" => ['title^20', 'author.folded^10', 'artist.folded^10', 'callnum', 'callnums', 'items.barcode', 'subjects.stem', 'stdnum', 'series', 'addl_author.folded', 'addl_title', 'title_medium']
+                  "fields" => ['title^20', 'author.folded^10', 'artist.folded^10', 'callnum', 'callnums', 'items.barcode', 'subjects.stem', 'stdnum', 'series', 'addl_author.folded', 'addl_title', 'pub_info', 'title_medium'],
                 ],
               ],
               /* 
@@ -382,7 +397,8 @@ class ArborElasticQuery
                     [
                       'query_string' => [
                         "query" => $this->query,
-                        "fields" => ['notes', 'subjects.stem'],
+                        "fields" => ['notes', 'pub_info', 'subjects.stem'],
+                        "analyzer" => "aadl_search_analyzer",
                         "default_operator" => 'and'
                       ],
                     ],
@@ -437,14 +453,6 @@ class ArborElasticQuery
                           "boost" => 0.3
                         ]
                       ],
-                    ],
-                    [
-                      'combined_fields' => [
-                        "query" => $stop_query,
-                        "fields" => ['title', 'author', 'artist', 'callnum', 'callnums', 'subjects', 'series', 'addl_author', 'addl_title', 'title_medium', 'notes'],
-                        "minimum_should_match" => "3<75%",
-                        "boost" => 4
-                      ]
                     ]
                   ]
                 ]
@@ -517,6 +525,7 @@ class ArborElasticQuery
                   'query_string' => [
                     "query" => '"' . $this->query . '"',
                     "fields" => ['notes', 'subjects.stem'],
+                    "analyzer" => "aadl_search_analyzer",
                     "default_operator" => 'and'
                   ],
                 ],
@@ -524,7 +533,7 @@ class ArborElasticQuery
                   'query_string' => [
                     "query" => $this->query,
                     "fields" => ['title', 'author', 'artist', 'subjects', 'series', 'addl_author', 'addl_title', 'title_medium'],
-                    "minimum_should_match" => "3<75%",
+                    "default_operator" => "and",
                     "boost" => 0
                   ]
                 ],

--- a/src/Search/ArborElasticQuery.php
+++ b/src/Search/ArborElasticQuery.php
@@ -391,7 +391,7 @@ class ArborElasticQuery
                       'combined_fields' => [
                         "query" => $stop_query,
                         "fields" => ['title', 'author', 'artist', 'callnum', 'callnums', 'subjects', 'series', 'addl_author', 'addl_title', 'title_medium', 'notes'],
-                        "minimum_should_match" => "3<4"
+                        "minimum_should_match" => "3<-10%"
                       ],
                     ],
                     [
@@ -502,11 +502,10 @@ class ArborElasticQuery
                       'simple_query_string' => [
                         "fields" => ['title.folded'],
                         "query" =>  $fQuery,
-                        "boost" => .5,
+                        "minimum_should_match" => '2<80%'
                       ]
-
                     ],
-                    'min_score' => 100
+                    'min_score' => 25
                   ]
                 ],
                 [
@@ -532,9 +531,8 @@ class ArborElasticQuery
                 [
                   'query_string' => [
                     "query" => $this->query,
-                    "fields" => ['title', 'author', 'artist', 'subjects', 'series', 'addl_author', 'addl_title', 'title_medium'],
-                    "default_operator" => "and",
-                    "boost" => 0
+                    "fields" => ['title', 'author', 'artist', 'subjects', 'series', 'addl_author', 'addl_title', 'title_medium', 'pub_info'],
+                    "analyzer" => "aadl_search_analyzer"
                   ]
                 ],
               ],

--- a/src/Search/ArborElasticQuery.php
+++ b/src/Search/ArborElasticQuery.php
@@ -373,7 +373,7 @@ class ArborElasticQuery
               [
                 'multi_match' => [
                   "query" => strtolower($this->query),
-                  "fields" => ['title^20', 'author.folded^10', 'artist.folded^10', 'callnum', 'callnums', 'items.barcode', 'subjects.stem', 'stdnum', 'series', 'addl_author.folded', 'addl_title', 'pub_info', 'title_medium'],
+                  "fields" => ['title^20', 'author.folded^10', 'artist.folded^10', 'callnum', 'callnums', 'items.barcode', 'subjects.stem', 'stdnum', 'series', 'addl_author.folded', 'addl_title', 'pub_info', 'notes', 'title_medium'],
                 ],
               ],
               /* 


### PR DESCRIPTION
Spoke w/ Sara about these changes today, including reviewing the most recent adjustments from this morning. She's approved.

This PR resolves a couple hard problems in addition to adjusting weights slightly to improve title fuzz results and reduce result bloat on long search terms. 

Problems fixed
- Searches for publisher info without specifically referencing field will return. [New](https://dev.aadl.org/search/catalog/neon%20hemlock) | [Old](https://aadl.org/search/catalog/neon%20hemlock)

- Searches against series will look for complete term matching rather than exact full-text matching to prevent searches for series with shorter names encompassing series that contain the same term in a longer phrase [New](https://dev.aadl.org/search/catalog/series:%22Tomes%20&%20tea%22) | [Old](https://aadl.org/search/catalog/series:%22Tomes%20&%20tea%22)

Weights adjusted
- Weighting for title fuzz has been adjusted so that a fuzzed titles return as the strongest match more often than broader multi-field searches. Together, these query clauses are intended to correct for both spelling mistakes and missing words. In the recent changes, missing words were getting too much priority. But minor variations in both should work.
- This change also prevents runaway results on searches for very long titles

Some examples of the weight changes
- Improved title fuzz priority on shorter searches. This title doesn't exist in our catalog, but directly related titles should return more readily. [New](https://dev.aadl.org/search/catalog/escape%20plan%20extractors) | [Old](https://aadl.org/search/catalog/escape%20plan%20extractor)
- Preventing runaway results on long titles. The ranking was usually good enough to compensate, but these searches should not be returning capped results since they're very specific. This is an extreme example: [New](https://dev.aadl.org/search/catalog/The%20Girl%20Who%20Circumnavigated%20Fairyland%20in%20a%20Ship%20of%20Her%20Own%20Making) | [Old](https://aadl.org/search/catalog/The%20Girl%20Who%20Circumnavigated%20Fairyland%20in%20a%20Ship%20of%20Her%20Own%20Making)
- A mix of spelling mistakes and missing words is still accepted with these changes. Example: searching for The guernsey literary pie socity (sic) instead of a fuller title without mistakes. Both still offer good results. [New](https://dev.aadl.org/search/catalog/The%20guernsey%20literary%20pie%20socity) | [Old](https://aadl.org/search/catalog/The%20guernsey%20literary%20pie%20socity)